### PR TITLE
Update ATTM System Usage Script V1.2.ps1

### DIFF
--- a/Windows_System_Usage/ATTM System Usage Script V1.2.ps1
+++ b/Windows_System_Usage/ATTM System Usage Script V1.2.ps1
@@ -785,8 +785,8 @@ $SearchXML = $ExecutionContext.InvokeCommand.ExpandString($SearchXML)
         if ($_.ID -eq 4624) {
             $User = $_.properties | Select-Object -Index 5
             $User = $User.value
-            $user = $user.TrimStart(".\AzureAD\")
-            $user = $user.TrimStart("AzureAD\")
+            $User = $User -Replace '^\.AzureAD\', ''
+            $User = $User -Replace '^AzureAD\', ''
            
     
             #Pull and translate the logon type to a human readable value
@@ -928,8 +928,8 @@ $SearchXML = $ExecutionContext.InvokeCommand.ExpandString($SearchXML)
                 $User = $_.properties | Select-Object -Index 5
                 $User = $User.value
                 #Trim Azure AD possible starting characters
-                $user = $user.TrimStart(".\AzureAD\")
-                $user = $user.TrimStart("AzureAD\")
+                $User = $User -Replace '^\.AzureAD\', ''
+                $User = $User -Replace '^AzureAD\', ''
       
       
                 #Pull and translate the logon type to a human readable value


### PR DESCRIPTION
Removed the use of .TrimStart() and instead use -Replace

For example 
$user = $user.TrimStart(".\AzureAD\") 
turns "Administrator" into "dministrator"