### PR TITLE
Update extension bundle version range in host.json

### DIFF
--- a/Function_App/2.1/DCRLogIngestAPI/host.json
+++ b/Function_App/2.1/DCRLogIngestAPI/host.json
@@ -10,7 +10,7 @@
   },
   "extensionBundle": {
     "id": "Microsoft.Azure.Functions.ExtensionBundle",
-    "version": "[3.*, 4.0.0)"
+    "version": "[4.*, 5.0.0)"
   },
   "managedDependency": {
     "enabled": true


### PR DESCRIPTION
The current host.json is using a deprecated version (v3.41.0) of extension bundles.